### PR TITLE
CI: Add Travis Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+
+matrix:
+  allow_failures:
+    - python: "3.5"
+
+addons:
+  apt:
+    packages:
+      - libhdf5-serial-dev
+
+install:
+  - pip install -r requirements.txt
+
+script: 
+  - ./createExamples_h5.py
+  - ./checkOpenPMD_h5.py -i example.h5 --EDPIC

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy>=1.6.1
+python-dateutil>=2.3.0
+h5py>=2.0.0


### PR DESCRIPTION
Adds integration to travis-ci for the validator and example creator script.

A `requirements.txt` file was added to track external dependencies of the scripts.
