### PR TITLE
`basePath`: Fixed to "/data/%T/"

### DIFF
--- a/checkOpenPMD_h5.py
+++ b/checkOpenPMD_h5.py
@@ -357,7 +357,7 @@ def check_root_attr(f, v, pic):
     #   required
     result_array += test_attr(f, v, "required", "openPMD", np.string_, "^[0-9]+\.[0-9]+\.[0-9]+$")
     result_array += test_attr(f, v, "required", "openPMDextension", np.uint32)
-    result_array += test_attr(f, v, "required", "basePath", np.string_)
+    result_array += test_attr(f, v, "required", "basePath", np.string_, "^\/data\/\%T\/$")
     result_array += test_attr(f, v, "required", "meshesPath", np.string_)
     result_array += test_attr(f, v, "required", "particlesPath", np.string_)
     result_array += test_attr(f, v, "required", "iterationEncoding", np.string_)

--- a/checkOpenPMD_h5.py
+++ b/checkOpenPMD_h5.py
@@ -360,8 +360,16 @@ def check_root_attr(f, v, pic):
     result_array += test_attr(f, v, "required", "basePath", np.string_, "^\/data\/\%T\/$")
     result_array += test_attr(f, v, "required", "meshesPath", np.string_)
     result_array += test_attr(f, v, "required", "particlesPath", np.string_)
-    result_array += test_attr(f, v, "required", "iterationEncoding", np.string_)
+    result_array += test_attr(f, v, "required", "iterationEncoding", np.string_, "^groupBased|fileBased$")
     result_array += test_attr(f, v, "required", "iterationFormat", np.string_)
+
+    # groupBased iteration encoding needs to match basePath
+    if result_array[0] == 0 :
+        if f.attrs["iterationEncoding"].decode() == "groupBased" :
+            if f.attrs["iterationFormat"].decode() != f.attrs["basePath"].decode() :
+                print("Error: for groupBased iterationEncoding the basePath "
+                      "and iterationFormat must match!")
+                result_array += np.array([1,0])
 
     #   recommended
     result_array += test_attr(f, v, "recommended", "author", np.string_)


### PR DESCRIPTION
In version `1.0.0` of the standard the string in `basePath` is fixed to `/data/%T/`.

We (ab)use our string regex comparison functionality to compare with that fixed string.

Also, the `iterationFormat` string is fixed to the same entry as `basePath` if `iterationEncoding` with `groupBased` is used.

~~

Spotted by @PrometheusPi and @Rahmspinat
All examples in `openPMD/openPMD-example-datasets` will need a tiny update see https://github.com/openPMD/openPMD-example-datasets/issues/5

~~
### Example errors

```
$ ./checkOpenPMD_h5.py -i example.h5                                                                                                                                     
Error: Attribute basePath in `/` does not satisfy format ('/data/%Taa/' should be in format '^\/data\/\%T\/')!
Error: it seems that the path of the data within the HDF5 file is not of the form '/data/%T/', where %T corresponds to an actual integer.
Result: 2 Errors and 0 Warnings.

$ ./checkOpenPMD_h5.py -i example.h5                                                                                                                                             
Error: Attribute basePath in `/` does not satisfy format ('/data/%Taa/' should be in format '^\/data\/\%T\/')!
Error: it seems that the path of the data within the HDF5 file is not of the form '/data/%T/', where %T corresponds to an actual integer.
Result: 2 Errors and 0 Warnings.

$ ./checkOpenPMD_h5.py -i example.h5                                                                                                                                             
Error: Attribute basePath in `/` does not satisfy format ('/data/{}/' should be in format '^\/data\/\%T\/')!
Error: it seems that the path of the data within the HDF5 file is not of the form '/data/%T/', where %T corresponds to an actual integer.
Result: 2 Errors and 0 Warnings.

$ ./checkOpenPMD_h5.py -i example.h5                                                                                                                     (fix-basePathFixed *%=)
Error: for groupBased iterationEncoding the basePath and iterationFormat must match!
Found 1 iteration(s)
Iteration 0 : found 3 meshes
Iteration 0 : found 1 particle species
Result: 1 Errors and 0 Warnings.
```
