### PR TITLE
Creator: iterationEncoding group based

### DIFF
--- a/createExamples_h5.py
+++ b/createExamples_h5.py
@@ -78,7 +78,7 @@ def setup_root_attr(f):
     f.attrs["basePath"] = np.string_("/data/%T/")
     f.attrs["meshesPath"] = np.string_("meshes/")
     f.attrs["particlesPath"] = np.string_("particles/")
-    f.attrs["iterationEncoding"] = np.string_("fileBased")
+    f.attrs["iterationEncoding"] = np.string_("groupBased")
     f.attrs["iterationFormat"] = np.string_("/data/%T/")
 
     # Recommended attributes


### PR DESCRIPTION
The example script generates a single `example.h5` which has no iteration encoding in the naming and must therefore identify its iteration via the `groupBased` `iterationEncoding`.

See: https://github.com/openPMD/openPMD-standard/blob/1.0.0/STANDARD.md#iterations-and-time-series
