### PR TITLE
Auto-detect PIC extension

### DIFF
--- a/checkOpenPMD_h5.py
+++ b/checkOpenPMD_h5.py
@@ -810,6 +810,12 @@ if __name__ == "__main__":
     # root attributes at "/"
     result_array = np.array([0, 0])
     result_array += check_root_attr(f, verbose, extension_pic)
+    
+    # Check for enabled extensions (After checking root attributes so we
+    # can detect if one is missing from the attribute)
+    valid, extensionIDs = get_attr(f, "openPMDextension")
+    if valid and (ext_list["ED-PIC"] & extensionIDs) == ext_list["ED-PIC"]:
+        extension_pic = True
 
     # Go through all the iterations, checking both the particles
     # and the meshes
@@ -821,3 +827,4 @@ if __name__ == "__main__":
 
     # return code: non-zero is unix-style for errors occured
     sys.exit(int(result_array[0]))
+

--- a/checkOpenPMD_h5.py
+++ b/checkOpenPMD_h5.py
@@ -38,7 +38,7 @@ def parse_cmd(argv):
     """ Parse the command line arguments """
     file_name = ''
     verbose = False
-    extension_pic = False
+    force_extension_pic = False
     try:
         opts, args = getopt.getopt(argv,"hvi:e",["file=","EDPIC"])
     except getopt.GetoptError:
@@ -50,13 +50,13 @@ def parse_cmd(argv):
         elif opt in ("-v", "--verbose"):
             verbose = True
         elif opt in ("--EDPIC"):
-            extension_pic = True
+            force_extension_pic = True
         elif opt in ("-i", "--file"):
             file_name = arg
     if not os.path.isfile(file_name):
         print("File '%s' not found!" % file_name)
         help()
-    return(file_name, verbose, extension_pic)
+    return(file_name, verbose, force_extension_pic)
 
 
 def open_file(file_name):
@@ -826,7 +826,7 @@ def check_particles(f, iteration, v, extensionStates) :
 
     
 if __name__ == "__main__":
-    file_name, verbose, extension_pic = parse_cmd(sys.argv[1:])
+    file_name, verbose, force_extension_pic = parse_cmd(sys.argv[1:])
     f = open_file(file_name)
 
     # root attributes at "/"
@@ -834,7 +834,7 @@ if __name__ == "__main__":
     result_array += check_root_attr(f, verbose)
     
     extensionStates = get_extensions(f, verbose)
-    if extension_pic and not extensionStates["ED-PIC"] :
+    if force_extension_pic and not extensionStates["ED-PIC"] :
         print("Error: Extension `ED-PIC` not found in file!")
         result_array += np.array([1, 0])
 

--- a/checkOpenPMD_h5.py
+++ b/checkOpenPMD_h5.py
@@ -54,6 +54,7 @@ def parse_cmd(argv):
         elif opt in ("-i", "--file"):
             file_name = arg
     if not os.path.isfile(file_name):
+        print("File '%s' not found!" % file_name)
         help()
     return(file_name, verbose, extension_pic)
 

--- a/checkOpenPMD_h5.py
+++ b/checkOpenPMD_h5.py
@@ -348,7 +348,7 @@ def test_component(c, v) :
     return(result_array)
 
 
-def check_root_attr(f, v, requiredExtensions):
+def check_root_attr(f, v):
     """
     Scan the root of the file and make sure that all the attributes are present
 
@@ -359,9 +359,6 @@ def check_root_attr(f, v, requiredExtensions):
         
     v : bool
         Verbose option
-    
-    requiredExtensions : list of extension names
-        extensions that should be enabled
 
     Returns
     -------
@@ -402,15 +399,6 @@ def check_root_attr(f, v, requiredExtensions):
 
     #   optional
     result_array += test_attr(f, v, "optional", "comment", np.string_)
-
-    valid, extensionIDs = get_attr(f, "openPMDextension")
-    if valid:
-        for extension in requiredExtensions:
-            if (ext_list[extension] & extensionIDs) != ext_list[extension]:
-                print("Error: ID=%s for extension `%s` not found in " \
-                      "`openPMDextension` (is %s)!" \
-                     %(ext_list[extension], extension, extensionIDs) )
-                result_array += np.array([1,0])
 
     return(result_array)
 
@@ -824,15 +812,15 @@ def check_particles(f, iteration, v, extensionStates) :
 if __name__ == "__main__":
     file_name, verbose, extension_pic = parse_cmd(sys.argv[1:])
     f = open_file(file_name)
-    requiredExtensions = []
-    if extension_pic:
-        requiredExtensions.append('ED-PIC')
 
     # root attributes at "/"
     result_array = np.array([0, 0])
-    result_array += check_root_attr(f, verbose, requiredExtensions)
+    result_array += check_root_attr(f, verbose)
     
     extensionStates = get_extensions(f, verbose)
+    if extension_pic and not extensionStates["ED-PIC"] :
+        print("Error: Extension `ED-PIC` not enabled!")
+        result_array += np.array([1, 0])
 
     # Go through all the iterations, checking both the particles
     # and the meshes

--- a/checkOpenPMD_h5.py
+++ b/checkOpenPMD_h5.py
@@ -78,21 +78,37 @@ def get_attr(f, name):
         
 def get_extensions(f, v):
     """
-    Get a dictionary which maps each extension name to a bool whether it is enabled in the file
+    Get a dictionary which maps each extension name to a bool whether it is
+    enabled in the file
+
+    Parameters
+    ----------
+    f : an h5py.File or h5py.Group object
+        The object in which to find claimed extensions
+    v : bool
+        Verbose option
+    
+    Returns
+    -------
+    A dictionary {string:bool} where the keys are the extension names and the
+    bool states whether it is enabled or not
     """
     valid, extensionIDs = get_attr(f, "openPMDextension")
     result = {ext: False for ext in ext_list.keys()}
     if valid:
         enabledExtMask = 0
-        for extension in ext_list.keys():
-            if (ext_list[extension] & extensionIDs) == ext_list[extension]:
+        for extension, bitmask in ext_list.items():
+            # This uses a bitmask to identify activated extensions
+            if (bitmask & extensionIDs) == bitmask:
                 result[extension] = True
-                enabledExtMask |= ext_list[extension]
+                enabledExtMask |= bitmask
                 if v:
                     print("Info: Found extension '%s'." % extension)
+        # Mask out the extension bits we have already detected so only
+        # unknown ones are left
         excessIDs = extensionIDs & ~enabledExtMask
         if excessIDs:
-            print("Warning: Unknown extension IDs: %s" % excessIDs)
+            print("Warning: Unknown extension Mask left: %s" % excessIDs)
     return result
        
         
@@ -416,7 +432,7 @@ def check_iterations(f, v, extensionStates) :
     v : bool
         Verbose option
     
-    extensionStates : Dictionary string:bool
+    extensionStates : Dictionary {string:bool}
         Whether an extension is enabled
 
     Returns
@@ -477,7 +493,7 @@ def check_base_path(f, iteration, v, extensionStates):
     v : bool
         Verbose option
         
-    extensionStates : Dictionary string:bool
+    extensionStates : Dictionary {string:bool}
         Whether an extension is enabled
     
     Returns
@@ -517,7 +533,7 @@ def check_meshes(f, iteration, v, extensionStates):
     v : bool
         Verbose option
         
-    extensionStates : Dictionary string:bool
+    extensionStates : Dictionary {string:bool}
         Whether an extension is enabled
     
     Returns
@@ -669,7 +685,7 @@ def check_particles(f, iteration, v, extensionStates) :
     v : bool
         Verbose option
         
-    extensionStates : Dictionary string:bool
+    extensionStates : Dictionary {string:bool}
         Whether an extension is enabled
     
     Returns
@@ -819,7 +835,7 @@ if __name__ == "__main__":
     
     extensionStates = get_extensions(f, verbose)
     if extension_pic and not extensionStates["ED-PIC"] :
-        print("Error: Extension `ED-PIC` not enabled!")
+        print("Error: Extension `ED-PIC` not found in file!")
         result_array += np.array([1, 0])
 
     # Go through all the iterations, checking both the particles

--- a/checkOpenPMD_h5.py
+++ b/checkOpenPMD_h5.py
@@ -24,7 +24,7 @@ import sys, getopt, os.path
 
 openPMD = "1.0.0"
 
-ext_list = [["ED-PIC", np.uint32(1)]]
+ext_list = {"ED-PIC": np.uint32(1)}
 
 def help():
     """ Print usage information for this file """
@@ -90,8 +90,8 @@ def test_record(g, r):
     Returns
     -------
     An array with 2 elements :
-    - The first element is 1 if an error occured, and 0 otherwise
-    - The second element is 0 if a warning arised, and 0 otherwise
+    - The first element is 1 if an error occurred, and 0 otherwise
+    - The second element is 0 if a warning arose, and 0 otherwise
     """
     regEx = re.compile("^\w+$") # Python3 only: re.ASCII
     if regEx.match(r):
@@ -113,7 +113,7 @@ def test_record(g, r):
 def test_key(f, v, request, name):
     """
     Checks whether a key is present. A key can either be
-    a h5py.Group or a h5py.Dataset.
+    a h5py.Group or a h5py.DataSet.
     Returns an error if the key if absent and requested
     Returns a warning if the key if absent and recommended
 
@@ -134,8 +134,8 @@ def test_key(f, v, request, name):
     Returns
     -------
     An array with 2 elements :
-    - The first element is 1 if an error occured, and 0 otherwise
-    - The second element is 0 if a warning arised, and 0 otherwise
+    - The first element is 1 if an error occurred, and 0 otherwise
+    - The second element is 0 if a warning arose, and 0 otherwise
     """
     valid = (name in list(f.keys()))
     if valid:
@@ -165,7 +165,7 @@ def test_attr(f, v, request, name, is_type=None, type_format=None):
     """
     Checks whether an attribute is present.
     Returns an error if the attribute if absent and requested
-    Returns a warning if the attribute if absent and recommanded
+    Returns a warning if the attribute if absent and recommended
 
     Parameters
     ----------
@@ -194,8 +194,8 @@ def test_attr(f, v, request, name, is_type=None, type_format=None):
     Returns
     -------
     An array with 2 elements :
-    - The first element is 1 if an error occured, and 0 otherwise
-    - The second element is 0 if a warning arised, and 0 otherwise
+    - The first element is 1 if an error occurred, and 0 otherwise
+    - The second element is 0 if a warning arose, and 0 otherwise
     """
     valid, value = get_attr(f, name)
     if valid:
@@ -271,7 +271,7 @@ def is_scalar_record(r):
 
     Parameters
     ----------
-    r : an h5py.Group or h5py.Dataset object
+    r : an h5py.Group or h5py.DataSet object
         the record that shall be tested
 
     Returns
@@ -298,7 +298,7 @@ def test_component(c, v) :
 
     Parameters
     ----------
-    c : an h5py.Group or h5py.Dataset object
+    c : an h5py.Group or h5py.DataSet object
         the record component that shall be tested
 
     v : bool
@@ -382,14 +382,16 @@ def check_root_attr(f, v, pic):
     #   optional
     result_array += test_attr(f, v, "optional", "comment", np.string_)
 
-    # Extension: ED-PIC
+    requiredExtensions = []
     if pic:
-        valid, extensionIDs = get_attr(f, "openPMDextension")
-        if valid:
-            if (ext_list[0][1] & extensionIDs) != extensionIDs:
+        requiredExtensions.append("ED-PIC")
+    valid, extensionIDs = get_attr(f, "openPMDextension")
+    if valid:
+        for extension in requiredExtensions:
+            if (ext_list[extension] & extensionIDs) != ext_list[extension]:
                 print("Error: ID=%s for extension `%s` not found in " \
                       "`openPMDextension` (is %s)!" \
-                     %(ext_list[0][1], ext_list[0][0], extensionIDs) )
+                     %(ext_list[extension], extension, extensionIDs) )
                 result_array += np.array([1,0])
 
     return(result_array)


### PR DESCRIPTION
This automatically detects if the ED-PIC extension is used and enables corresponding checks.

It also fixes the following minor issues on the way:
- Typos
- DataSet instead of Dataset (consistency)
- Print message about missing file (only showing help is confusing)
- Make ext_list a dictionary to make the enabled extensions check extensible
- Fix the extension check (it is a mask, so AND-ing it with the extension flag should result in the extension flag not in the mask)

ccing @ax3l 
