### PR TITLE
Use correct geometry

### DIFF
--- a/createExamples_h5.py
+++ b/createExamples_h5.py
@@ -121,7 +121,7 @@ def write_rho_cylindrical(meshes, mode0, mode1):
 
     # Create the dataset (cylindrical with azimuthal modes up to m=1)
     # The first axis has size 2m+1
-    rho.attrs["geometry"] = np.string_("cylindrical")
+    rho.attrs["geometry"] = np.string_("thetaMode")
     rho.attrs["geometryParameters"] = np.string_("m=1; imag=+")
 
     # Add information on the units of the data


### PR DESCRIPTION
The standard specifies that for cylindrical geometry, one should use `"thetaMode"` (the name `cylindrical` is "reserved" in the standard, but I don't think it means that it should be used.)