### PR TITLE
Bump Version: 1.1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,28 +43,28 @@ Choose *one* of the install methods below to get started:
 
 ```bash
 # optional: append --user
-pip install openPMD-validator==1.0.0.2
+pip install openPMD-validator==1.1.0.1
 ```
 
 ### Spack
 
 ```bash
-spack install py-openpmd-validator@1.0.0.2 ^py-h5py~mpi
-spack load --dependencies py-openpmd-validator@1.0.0.2 ^py-h5py~mpi
+spack install py-openpmd-validator@1.1.0.1 ^py-h5py~mpi
+spack load --dependencies py-openpmd-validator@1.1.0.1 ^py-h5py~mpi
 ```
 
 ### Conda
 
 ```bash
-conda install -c ax3l openpmd_validator==1.0.0.2
+conda install -c ax3l openpmd_validator==1.1.0.1
 ```
 
 ### From Source
 
 ```bash
-wget https://github.com/openPMD/openPMD-validator/archive/1.0.0.2.tar.gz
-tar -xf 1.0.0.2.tar.gz
-cd openPMD-validator-1.0.0.2/
+wget https://github.com/openPMD/openPMD-validator/archive/1.1.0.1.tar.gz
+tar -xf 1.1.0.1.tar.gz
+cd openPMD-validator-1.1.0.1/
 
 # optional: append --user
 python setup.py install

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.0.2" %}
+{% set version = "1.1.0.1" %}
 
 package:
   name: openpmd_validator

--- a/newVersion.sh
+++ b/newVersion.sh
@@ -98,6 +98,13 @@ sed -i 's/'\
 '\1'$VERSION_STR'\3/' \
     $REPO_DIR/conda_recipe/meta.yaml
 
+# example creator scripts
+#   hdf5
+sed -i 's/'\
+'\("softwareVersion".*\)'$regv'\(")\)/'\
+'\1'$VERSION_STR'\3/' \
+    $REPO_DIR/openpmd_validator/createExamples_h5.py
+
 # documentation
 sed -i 's/'\
 '\(.*validator==\)'$regv'\(.*\)/'\

--- a/openpmd_validator/createExamples_h5.py
+++ b/openpmd_validator/createExamples_h5.py
@@ -103,7 +103,7 @@ def setup_root_attr(f):
     # Recommended attributes
     f.attrs["author"] = np.string_("Axel Huebl <a.huebl@hzdr.de>")
     f.attrs["software"] = np.string_("openPMD Example Script")
-    f.attrs["softwareVersion"] = np.string_("1.0.0")
+    f.attrs["softwareVersion"] = np.string_("1.1.0.1")
     f.attrs["softwareDependencies"] = get_software_dependencies()
     f.attrs["machine"] = np.string_(socket.gethostname())
     f.attrs["date"] = np.string_(

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read_readme():
 
 setup(
     name='openPMD-validator',
-    version='1.0.0.2',
+    version='1.1.0.1',
     url='https://github.com/openPMD/openPMD-validator',
     # author=...,  # TODO
     # author_email=...,  # TODO


### PR DESCRIPTION
Bump the version of the validator scripts to `1.1.0.1`.

### Note

Let us merge this PR last!

- [x] We first release the `openPMD-standard 1.1.0`
- [x] After it is merged, we have to trigger our release build scripts (tag, packaging, publishing, etc.).
- [x] After this, we make the `1.1.X` branch the default branch of this repo.