### PR TITLE
New Attribute: speciesType

### DIFF
--- a/openpmd_validator/check_h5.py
+++ b/openpmd_validator/check_h5.py
@@ -26,13 +26,14 @@ import sys, getopt, os.path
 # version of the openPMD standard
 openPMD = "2.0.0"
 
-ext_list = ["ED-PIC"]
+ext_list = ["ED-PIC", "SpeciesType"]
 
 def help():
     """ Print usage information for this file """
     print('This is the openPMD file check for HDF5 files.\n')
     print('Check for format version: %s\n' % openPMD)
-    print('Usage:\n  checkOpenPMD_h5.py -i <fileName> [-v] [--EDPIC]')
+    print('Usage:\n  checkOpenPMD_h5.py -i <fileName> [-v] [--EDPIC] '
+          '[--SpeciesType]')
     sys.exit()
 
 
@@ -41,8 +42,10 @@ def parse_cmd(argv):
     file_name = ''
     verbose = False
     force_extension_pic = False
+    force_extension_speciestype = False
     try:
-        opts, args = getopt.getopt(argv,"hvi:e",["file=","EDPIC"])
+        opts, args = getopt.getopt(argv,"hvi:e",
+            ["file=","EDPIC", "SpeciesType"])
     except getopt.GetoptError:
         print('checkOpenPMD_h5.py -i <fileName>')
         sys.exit(2)
@@ -53,12 +56,14 @@ def parse_cmd(argv):
             verbose = True
         elif opt in ("--EDPIC"):
             force_extension_pic = True
+        elif opt in ("--SpeciesType"):
+            force_extension_speciestype = True
         elif opt in ("-i", "--file"):
             file_name = arg
     if not os.path.isfile(file_name):
         print("File '%s' not found!" % file_name)
         help()
-    return(file_name, verbose, force_extension_pic)
+    return file_name, verbose, force_extension_pic, force_extension_speciestype
 
 
 def open_file(file_name):
@@ -392,7 +397,7 @@ def check_root_attr(f, v):
     result_array += test_attr(f, v, "required", "iterationFormat", np.string_)
 
     #   optional but required for extensions
-    result_array += test_attr(f, v, "optional", "openPMDextension", np.string_, "^[a-zA-Z0-9-;]+$")
+    result_array += test_attr(f, v, "optional", "openPMDextension", np.string_, "^[a-zA-Z0-9\-;]+$")
     #   optional but required for data
     result_array += test_attr(f, v, "optional", "meshesPath", np.string_)
     result_array += test_attr(f, v, "optional", "particlesPath", np.string_)
@@ -677,6 +682,16 @@ def check_meshes(f, iteration, v, extensionStates):
             if (valid == True) and (field_smoothing != b"none") :
                 result_array += test_attr(field,v, "required",
                                     "fieldSmoothingParameters", np.string_)
+
+    # Check the attributes in the SpeciesType extension
+    if extensionStates['SpeciesType'] :
+        # Check for the attributes of each record
+        for field_name in list_meshes :
+            field = f[full_meshes_path + field_name.encode('ascii')]
+            result_array += test_attr(field, v, "optional",
+                                      "speciesType", np.string_,
+                                      "^[a-zA-Z0-9\-;:]+$")
+
     return(result_array)
 
 
@@ -824,6 +839,11 @@ def check_particles(f, iteration, v, extensionStates) :
                 result_array += test_attr(species, v, "required",
                                 "particleSmoothingParameters", np.string_)
 
+        # Check the attributes associated with the SpeciesType extension
+        if extensionStates['SpeciesType'] :
+            result_array += test_attr(species, v, "optional", "speciesType",
+                                      np.string_, "^[a-zA-Z0-9\-;:]+$")
+
         # Check attributes of each record of the particle
         for record in list(species.keys()) :
             # all records (but particlePatches) require units
@@ -851,7 +871,8 @@ def check_particles(f, iteration, v, extensionStates) :
     return(result_array)
 
 
-def check_file(file_name, verbose=False, force_extension_pic=False):
+def check_file(file_name, verbose=False, force_extension_pic=False,
+               force_extension_speciestype=False):
     f = open_file(file_name)
 
     # root attributes at "/"
@@ -862,6 +883,9 @@ def check_file(file_name, verbose=False, force_extension_pic=False):
     if force_extension_pic and not extensionStates["ED-PIC"] :
         print("Error: Extension `ED-PIC` not found in file!")
         result_array += np.array([1, 0])
+    if force_extension_speciestype and not extensionStates["SpeciesType"] :
+        print("Error: Extension `SpeciesType` not found in file!")
+        result_array += np.array([1, 0])
 
     # Go through all the iterations, checking both the particles
     # and the meshes
@@ -871,8 +895,10 @@ def check_file(file_name, verbose=False, force_extension_pic=False):
 
 
 def main():
-    file_name, verbose, force_extension_pic = parse_cmd(sys.argv[1:])
-    result_array = check_file(file_name, verbose, force_extension_pic)
+    file_name, verbose, \
+    force_extension_pic, force_extension_speciestype = parse_cmd(sys.argv[1:])
+    result_array = check_file(file_name, verbose,
+                              force_extension_pic, force_extension_speciestype)
 
     # results
     print("Result: %d Errors and %d Warnings."

--- a/openpmd_validator/check_h5.py
+++ b/openpmd_validator/check_h5.py
@@ -397,7 +397,9 @@ def check_root_attr(f, v):
     result_array += test_attr(f, v, "required", "iterationFormat", np.string_)
 
     #   optional but required for extensions
-    result_array += test_attr(f, v, "optional", "openPMDextension", np.string_, "^[a-zA-Z0-9\-;]+$")
+    result_array += test_attr(f, v, "optional", "openPMDextension", np.string_,
+                              # allowed are a-Z 0-9 - ; (but no spaces!)
+                              "^[a-zA-Z0-9\-;]+$")
     #   optional but required for data
     result_array += test_attr(f, v, "optional", "meshesPath", np.string_)
     result_array += test_attr(f, v, "optional", "particlesPath", np.string_)
@@ -688,6 +690,7 @@ def check_meshes(f, iteration, v, extensionStates):
         # Check for the attributes of each record
         for field_name in list_meshes :
             field = f[full_meshes_path + field_name.encode('ascii')]
+            # allowed are a-Z 0-9 - ; : (but no spaces!)
             result_array += test_attr(field, v, "optional",
                                       "speciesType", np.string_,
                                       "^[a-zA-Z0-9\-;:]+$")
@@ -841,6 +844,7 @@ def check_particles(f, iteration, v, extensionStates) :
 
         # Check the attributes associated with the SpeciesType extension
         if extensionStates['SpeciesType'] :
+            # allowed are a-Z 0-9 - ; : (but no spaces!)
             result_array += test_attr(species, v, "optional", "speciesType",
                                       np.string_, "^[a-zA-Z0-9\-;:]+$")
 

--- a/openpmd_validator/createExamples_h5.py
+++ b/openpmd_validator/createExamples_h5.py
@@ -88,8 +88,8 @@ def setup_root_attr(f):
         The file in which to write the data
     """
 
-    # extensions list: ED-PIC extension is used
-    ext_list = ["ED-PIC"]
+    # extensions list: ED-PIC and SpeciesType extensions are used
+    ext_list = ["ED-PIC", "SpeciesType"]
 
     # Required attributes
     f.attrs["openPMD"] = np.string_("2.0.0")
@@ -139,6 +139,7 @@ def write_rho_cylindrical(meshes, mode0, mode1):
     rho = meshes[full_rho_path]
     rho.attrs["comment"] = np.string_(
         "Density of electrons in azimuthal decomposition")
+    rho.attrs["speciesType"] = np.string_("electron")
 
     # Create the dataset (cylindrical with azimuthal modes up to m=1)
     # The first axis has size 2m+1
@@ -323,6 +324,7 @@ def add_EDPIC_attr_particles(particle):
                The group of the particle that gets additional attributes.
 
     """
+    particle.attrs["speciesType"] = np.string_("electron")
     particle.attrs["particleShape"] = 3.0
     particle.attrs["currentDeposition"] = np.string_("Esirkepov")
     # particle.attrs["currentDepositionParameters"] = np.string_("")


### PR DESCRIPTION
Check if the optional `speciesType` attribute in the `SpeciesType` extension is a string and uses only allowed characters (e.g. no spaces).

Introduced in openPMD 2.0.0: https://github.com/openPMD/openPMD-standard/pull/180