### PR TITLE
ED-PIC: Remove proton/neutron Number

### DIFF
--- a/openpmd_validator/check_h5.py
+++ b/openpmd_validator/check_h5.py
@@ -820,8 +820,6 @@ def check_particles(f, iteration, v, extensionStates) :
             result_array += test_key(species, v, "required", "mass")
             result_array += test_key(species, v, "required", "weighting")
             result_array += test_key(species, v, "optional", "boundElectrons")
-            result_array += test_key(species, v, "optional", "protonNumber")
-            result_array += test_key(species, v, "optional", "neutronNumber")
 
         # Check the attributes associated with the PIC extension
         if extensionStates['ED-PIC'] :


### PR DESCRIPTION
Remove the attributes for ions which can now be expressed via the `SpeciesType` extension.

Change in the standard for 2.0.0: https://github.com/openPMD/openPMD-standard/pull/192