### PR TITLE
Remove Data Order

### DIFF
--- a/openpmd_validator/check_h5.py
+++ b/openpmd_validator/check_h5.py
@@ -606,8 +606,6 @@ def check_meshes(f, iteration, v, extensionStates):
         result_array += test_attr(field, v, "required",
                                   "gridUnitDimension", np.ndarray, np.float64)
         result_array += test_attr(field, v, "required",
-                                  "dataOrder", np.string_)
-        result_array += test_attr(field, v, "required",
                                   "axisLabels", np.ndarray, np.string_)
         # Specific check for geometry
         geometry_test = test_attr(field, v, "required", "geometry", np.string_)

--- a/openpmd_validator/createExamples_h5.py
+++ b/openpmd_validator/createExamples_h5.py
@@ -165,8 +165,7 @@ def write_rho_cylindrical(meshes, mode0, mode1):
     rho.attrs["gridUnitDimension"] = \
         np.array( [1.,0.,0.,0.,0.,0.,0.,
                    1.,0.,0.,0.,0.,0.,0.], dtype=np.float64 )
-    rho.attrs["dataOrder"] = np.string_("C")
-    rho.attrs["axisLabels"] = np.array([b"r",b"z"])
+    rho.attrs["axisLabels"] = np.array([b"r", b"z"])  # rho[z, r]
 
     # Add specific information for PIC simulations
     add_EDPIC_attr_meshes(rho)
@@ -212,8 +211,7 @@ def write_b_2d_cartesian(meshes, data_ez):
     B.attrs["gridUnitDimension"] = \
         np.array( [1.,0.,0.,0.,0.,0.,0.,
                    1.,0.,0.,0.,0.,0.,0.], dtype=np.float64 )
-    B.attrs["dataOrder"] = np.string_("C")
-    B.attrs["axisLabels"] = np.array([b"x",b"y"])
+    B.attrs["axisLabels"] = np.array([b"x", b"y"])  # B[y, x]
     B.attrs["unitDimension"] = \
        np.array([0.0, 1.0, -2.0, -1.0, 0.0, 0.0, 0.0 ], dtype=np.float64)
        #          L    M     T     I  theta  N    J
@@ -278,8 +276,7 @@ def write_e_2d_cartesian(meshes, data_ex, data_ey, data_ez ):
     E.attrs["gridUnitDimension"] = \
         np.array( [1.,0.,0.,0.,0.,0.,0.,
                    1.,0.,0.,0.,0.,0.,0.], dtype=np.float64 )
-    E.attrs["dataOrder"] = np.string_("C")
-    E.attrs["axisLabels"] = np.array([b"x",b"y"])
+    E.attrs["axisLabels"] = np.array([b"x", b"y"])  # E[y, x]
     E.attrs["unitDimension"] = \
        np.array([1.0, 1.0, -3.0, -1.0, 0.0, 0.0, 0.0 ], dtype=np.float64)
        #          L    M     T     I  theta  N    J


### PR DESCRIPTION
Removes the `dataOrder` attribute for openPMD 2.0, see proposed change in https://github.com/openPMD/openPMD-standard/pull/194

Order of 1D-flattened attributes is now simply derived from indices of logical memory layout, ordered from fastest varying index to slowest varying index.