### PR TITLE
Species timeOffset: floatX

### DIFF
--- a/openpmd_validator/check_h5.py
+++ b/openpmd_validator/check_h5.py
@@ -854,9 +854,8 @@ def check_particles(f, iteration, v, extensionStates) :
             if record != "particlePatches":
                 result_array += test_attr(species[record], v,
                         "required", "unitDimension", np.ndarray, np.float64)
-                time_type = f[base_path].attrs["time"].dtype.type
                 result_array += test_attr(species[record], v, "required",
-                                          "timeOffset", time_type)
+                                          "timeOffset", [np.float32, np.float64])
                 if extensionStates['ED-PIC'] :
                     result_array += test_attr(species[record], v, "required",
                                               "weightingPower", np.float64)


### PR DESCRIPTION
Time offsets are for records in openPMD 1.X of any float type.
They don't need to take the same type as `basePath` attribute `time`.

Same as #47 but for the upcoming `2.X` release of openPMD.