### PR TITLE
Move particle Boundary from mesh to species attribute

### DIFF
--- a/openpmd_validator/check_h5.py
+++ b/openpmd_validator/check_h5.py
@@ -651,14 +651,6 @@ def check_meshes(f, iteration, v, extensionStates):
             result_array += test_attr(f[full_meshes_path], v, "required",
                         "fieldBoundaryParameters", np.ndarray, np.string_)
 
-        # Check for the attributes associated with the field boundaries
-        result_array += test_attr(f[full_meshes_path], v, "required",
-                                "particleBoundary", np.ndarray, np.string_)
-        valid, particle_boundary = get_attr(f[full_meshes_path], "particleBoundary")
-        if (valid == True) and (np.any(particle_boundary == b"other")) :
-            result_array += test_attr(f[full_meshes_path], v, "required",
-                    "particleBoundaryParameters", np.ndarray, np.string_)
-
         # Check the attributes associated with the current smoothing
         result_array += test_attr(f[full_meshes_path], v, "required",
                                   "currentSmoothing", np.string_)
@@ -831,6 +823,14 @@ def check_particles(f, iteration, v, extensionStates) :
                                       "particlePush", np.string_)
             result_array += test_attr(species, v, "required",
                                       "particleInterpolation", np.string_)
+
+            # Check for the attributes associated with the particle boundaries
+            result_array += test_attr(species, v, "required",
+                                    "particleBoundary", np.ndarray, np.string_)
+            valid, particle_boundary = get_attr(species, "particleBoundary")
+            if (valid == True) and (np.any(particle_boundary == b"other")) :
+                result_array += test_attr(species, v, "required",
+                        "particleBoundaryParameters", np.ndarray, np.string_)
 
             # Check for the attributes associated with the particle smoothing
             result_array += test_attr(species, v, "required",

--- a/openpmd_validator/createExamples_h5.py
+++ b/openpmd_validator/createExamples_h5.py
@@ -339,6 +339,8 @@ def add_EDPIC_attr_particles(particle):
     # particle.attrs["currentDepositionParameters"] = np.string_("")
     particle.attrs["particlePush"] = np.string_("Boris")
     particle.attrs["particleInterpolation"] = np.string_("uniform")
+    particle.attrs["particleBoundary"] = np.array(
+            [b"periodic", b"periodic", b"absorbing", b"absorbing"])
     particle.attrs["particleSmoothing"] = np.string_("none")
     # particle.attrs["particleSmoothingParameters"] = \
     #     np.string_("period=1;numPasses=2;compensator=false")
@@ -353,8 +355,6 @@ def write_meshes(f, iteration):
     meshes.attrs["fieldSolver"] = np.string_("Yee")
     meshes.attrs["fieldBoundary"] = np.array(
         [b"periodic", b"periodic", b"open", b"open"])
-    meshes.attrs["particleBoundary"] = np.array(
-        [b"periodic", b"periodic", b"absorbing", b"absorbing"])
     meshes.attrs["currentSmoothing"] = np.string_("Binomial")
     meshes.attrs["currentSmoothingParameters"] = \
          np.string_("period=1;numPasses=2;compensator=false")


### PR DESCRIPTION
This implements [PR #202 of the standard](https://github.com/openPMD/openPMD-standard/pull/202): the attribute `particleBoundary` has been moved to a species attribute.