### PR TITLE
floatX: also float128

### DIFF
--- a/openpmd_validator/check_h5.py
+++ b/openpmd_validator/check_h5.py
@@ -248,6 +248,7 @@ def test_attr(f, v, request, name, is_type=None, type_format=None):
 
         # test type
         if is_type is not None:
+            type_format_names = None
             if not type_format is None and not is_type is np.string_ and \
                not isinstance(type_format, Iterable):
                 type_format = [type_format]
@@ -522,8 +523,8 @@ def check_base_path(f, iteration, v, extensionStates):
     bp = f[base_path]
 
     # Check for the attributes of the STANDARD.md
-    result_array += test_attr(bp, v, "required", "time", [np.float32, np.float64])
-    result_array += test_attr(bp, v, "required", "dt", [np.float32, np.float64])
+    result_array += test_attr(bp, v, "required", "time", [np.float32, np.float64, np.float128])
+    result_array += test_attr(bp, v, "required", "dt", [np.float32, np.float64, np.float128])
     result_array += test_attr(bp, v, "required", "timeUnitSI", np.float64)
 
     return(result_array)
@@ -624,14 +625,14 @@ def check_meshes(f, iteration, v, extensionStates):
         if is_scalar_record(field) :   # If the record is a scalar field
             result_array += test_component(field, v)
             result_array += test_attr(field, v,
-                                "required", "position", np.ndarray, [np.float32, np.float64])
+                                "required", "position", np.ndarray, [np.float32, np.float64, np.float128])
         else:                          # If the record is a vector field
             # Loop over the components
             for component_name in list(field.keys()) :
                 component = field[component_name]
                 result_array += test_component(component, v)
                 result_array += test_attr(component, v,
-                                "required", "position", np.ndarray, [np.float32, np.float64])
+                                "required", "position", np.ndarray, [np.float32, np.float64, np.float128])
 
     # Check for the attributes of the PIC extension,
     # if asked to do so by the user 
@@ -816,7 +817,7 @@ def check_particles(f, iteration, v, extensionStates) :
         # Check the attributes associated with the PIC extension
         if extensionStates['ED-PIC'] :
             result_array += test_attr(species, v, "required",
-                                      "particleShape", [np.float32, np.float64])
+                                      "particleShape", [np.float32, np.float64, np.float128])
             result_array += test_attr(species, v, "required",
                                       "currentDeposition", np.string_)
             result_array += test_attr(species, v, "required",
@@ -839,7 +840,7 @@ def check_particles(f, iteration, v, extensionStates) :
                 result_array += test_attr(species[record], v,
                         "required", "unitDimension", np.ndarray, np.float64)
                 result_array += test_attr(species[record], v, "required",
-                                          "timeOffset", [np.float32, np.float64])
+                                          "timeOffset", [np.float32, np.float64, np.float128])
                 if extensionStates['ED-PIC'] :
                     result_array += test_attr(species[record], v, "required",
                                               "weightingPower", np.float64)


### PR DESCRIPTION
openPMD *(floatX)* can also include float128, which is the default in Python (`long double` on x86_64 Linux).

Also fixes an uninitialized variable in an error report.

Same as #60