### PR TITLE
Fix: np.float -> np.floatXY

### DIFF
--- a/openpmd_validator/createExamples_h5.py
+++ b/openpmd_validator/createExamples_h5.py
@@ -237,9 +237,9 @@ def write_b_2d_cartesian(meshes, data_ez):
     #   the constant record components B.x and B.y have the same shape
     #   (== same mesh discretization) as the non-constant record
     #   component B.z
-    B["x"].attrs["value"] = np.float(0.0)
+    B["x"].attrs["value"] = np.float64(0.0)
     B["x"].attrs["shape"] = np.array(data_ez.shape, dtype=np.uint64)
-    B["y"].attrs["value"] = np.float(0.0)
+    B["y"].attrs["value"] = np.float64(0.0)
     B["y"].attrs["shape"] = np.array(data_ez.shape, dtype=np.uint64)
     B["z"][:,:] =  data_ez[:,:]
 


### PR DESCRIPTION
AttributeError: module 'numpy' has no attribute 'float'. `np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.