### PR TITLE
Numpy 2.0: `np.string_` -> `np.bytes_`

### DIFF
--- a/openpmd_validator/check_h5.py
+++ b/openpmd_validator/check_h5.py
@@ -239,7 +239,7 @@ def test_attr(f, v, request, name, is_type=None, type_format=None):
 
     type_format: (numpy or python) data type
         Used with is_type to specify numpy ndarray dtypes or a
-        base np.string_ format regex. Can be a list of data types
+        base np.bytes_ format regex. Can be a list of data types
         for ndarrays where at least one data type must match.
 
     Returns
@@ -257,7 +257,7 @@ def test_attr(f, v, request, name, is_type=None, type_format=None):
         # test type
         if is_type is not None:
             type_format_names = None
-            if not type_format is None and not is_type is np.string_ and \
+            if not type_format is None and not is_type is np.bytes_ and \
                not isinstance(type_format, Iterable):
                 type_format = [type_format]
                 type_format_names = map(lambda x: x.__name__, type_format)
@@ -266,8 +266,8 @@ def test_attr(f, v, request, name, is_type=None, type_format=None):
             is_type_names = "' or '".join(map(lambda x: str(x.__name__), is_type))
             # add for each type in is_type -> wrong, need to add this at the comparison level!
             if type(value) in is_type:
-                # np.string_ format or general ndarray dtype text
-                if type(value) is np.string_ and type_format is not None:
+                # np.bytes_ format or general ndarray dtype text
+                if type(value) is np.bytes_ and type_format is not None:
                     regEx = re.compile(type_format) # Python3 only: re.ASCII
                     if regEx.match(value.decode()) :
                         result_array = np.array([0,0])
@@ -404,18 +404,18 @@ def check_root_attr(f, v):
 
     # STANDARD.md
     #   required
-    result_array += test_attr(f, v, "required", "openPMD", np.string_, "^[0-9]+\.[0-9]+\.[0-9]+$")
-    result_array += test_attr(f, v, "required", "basePath", np.string_, "^\/data\/\%T\/$")
-    result_array += test_attr(f, v, "required", "iterationEncoding", np.string_, "^groupBased|fileBased$")
-    result_array += test_attr(f, v, "required", "iterationFormat", np.string_)
+    result_array += test_attr(f, v, "required", "openPMD", np.bytes_, "^[0-9]+\.[0-9]+\.[0-9]+$")
+    result_array += test_attr(f, v, "required", "basePath", np.bytes_, "^\/data\/\%T\/$")
+    result_array += test_attr(f, v, "required", "iterationEncoding", np.bytes_, "^groupBased|fileBased$")
+    result_array += test_attr(f, v, "required", "iterationFormat", np.bytes_)
 
     #   optional but required for extensions
-    result_array += test_attr(f, v, "optional", "openPMDextension", np.string_,
+    result_array += test_attr(f, v, "optional", "openPMDextension", np.bytes_,
                               # allowed are a-Z 0-9 - ; (but no spaces!)
                               "^[a-zA-Z0-9\-;]+$")
     #   optional but required for data
-    result_array += test_attr(f, v, "optional", "meshesPath", np.string_, "^.*\/$")
-    result_array += test_attr(f, v, "optional", "particlesPath", np.string_, "^.*\/$")
+    result_array += test_attr(f, v, "optional", "meshesPath", np.bytes_, "^.*\/$")
+    result_array += test_attr(f, v, "optional", "particlesPath", np.bytes_, "^.*\/$")
 
     # groupBased iteration encoding needs to match basePath
     if result_array[0] == 0 :
@@ -426,17 +426,17 @@ def check_root_attr(f, v):
                 result_array += np.array([1,0])
 
     #   recommended
-    result_array += test_attr(f, v, "recommended", "author", np.string_)
-    result_array += test_attr(f, v, "recommended", "software", np.string_)
+    result_array += test_attr(f, v, "recommended", "author", np.bytes_)
+    result_array += test_attr(f, v, "recommended", "software", np.bytes_)
     result_array += test_attr(f, v, "recommended",
-                              "softwareVersion", np.string_)
-    result_array += test_attr(f, v, "recommended", "date", np.string_,
+                              "softwareVersion", np.bytes_)
+    result_array += test_attr(f, v, "recommended", "date", np.bytes_,
       "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [\+|-][0-9]{4}$")
 
     #   optional
-    result_array += test_attr(f, v, "optional", "softwareDependencies", np.string_)
-    result_array += test_attr(f, v, "optional", "machine", np.string_)
-    result_array += test_attr(f, v, "optional", "comment", np.string_)
+    result_array += test_attr(f, v, "optional", "softwareDependencies", np.bytes_)
+    result_array += test_attr(f, v, "optional", "machine", np.bytes_)
+    result_array += test_attr(f, v, "optional", "comment", np.bytes_)
 
     return(result_array)
 
@@ -619,18 +619,18 @@ def check_meshes(f, iteration, v, extensionStates):
         result_array += test_attr(field, v, "required",
                                   "gridUnitDimension", np.ndarray, np.double)
         result_array += test_attr(field, v, "required",
-                                  "axisLabels", np.ndarray, np.string_)
+                                  "axisLabels", np.ndarray, np.bytes_)
         # Specific check for geometry
-        geometry_test = test_attr(field, v, "required", "geometry", np.string_)
+        geometry_test = test_attr(field, v, "required", "geometry", np.bytes_)
         result_array += geometry_test
         # geometryParameters is required when using thetaMode
         if geometry_test[0] == 0 and field.attrs["geometry"] == b"thetaMode" :
             result_array += test_attr(field, v, "required",
-                                            "geometryParameters", np.string_)
+                                            "geometryParameters", np.bytes_)
         # otherwise it is optional
         else :
             result_array += test_attr(field, v, "optional",
-                                            "geometryParameters", np.string_)
+                                            "geometryParameters", np.bytes_)
 
         # Attributes of the record's components
         if is_scalar_record(field) :   # If the record is a scalar field
@@ -650,45 +650,45 @@ def check_meshes(f, iteration, v, extensionStates):
     if extensionStates['ED-PIC'] and len(list_meshes) > 0:
         # Check the attributes associated with the field solver
         result_array += test_attr(f[full_meshes_path], v, "required",
-                                  "fieldSolver", np.string_)
+                                  "fieldSolver", np.bytes_)
         valid, field_solver = get_attr(f[full_meshes_path], "fieldSolver")
         if (valid == True) and (field_solver in ["other", "GPSTD"]) :
             result_array += test_attr(f[full_meshes_path], v, "required",
-                                      "fieldSolverParameters", np.string_)
+                                      "fieldSolverParameters", np.bytes_)
 
         # Check for the attributes associated with the field boundaries
         result_array += test_attr(f[full_meshes_path], v, "required",
-                                "fieldBoundary", np.ndarray, np.string_)
+                                "fieldBoundary", np.ndarray, np.bytes_)
         valid, field_boundary = get_attr(f[full_meshes_path], "fieldBoundary")
         if (valid == True) and (np.any(field_boundary == b"other")) :
             result_array += test_attr(f[full_meshes_path], v, "required",
-                        "fieldBoundaryParameters", np.ndarray, np.string_)
+                        "fieldBoundaryParameters", np.ndarray, np.bytes_)
 
         # Check the attributes associated with the current smoothing
         result_array += test_attr(f[full_meshes_path], v, "required",
-                                  "currentSmoothing", np.string_)
+                                  "currentSmoothing", np.bytes_)
         valid, current_smoothing = get_attr(f[full_meshes_path], "currentSmoothing")
         if (valid == True) and (current_smoothing != b"none") :
             result_array += test_attr(f[full_meshes_path], v, "required",
-                        "currentSmoothingParameters", np.string_)
+                        "currentSmoothingParameters", np.bytes_)
 
         # Check the attributes associated with the charge conservation
         result_array += test_attr(f[full_meshes_path], v, "required",
-                                  "chargeCorrection", np.string_)
+                                  "chargeCorrection", np.bytes_)
         valid, charge_correction = get_attr(f[full_meshes_path], "chargeCorrection")
         if valid == True and charge_correction != b"none":
             result_array += test_attr(f[full_meshes_path], v, "required",
-                        "chargeCorrectionParameters", np.string_)
+                        "chargeCorrectionParameters", np.bytes_)
 
         # Check for the attributes of each record
         for field_name in list_meshes :
             field = f[full_meshes_path + field_name.encode('ascii')]
             result_array + test_attr(field, v, "required",
-                                     "fieldSmoothing", np.string_)
+                                     "fieldSmoothing", np.bytes_)
             valid, field_smoothing = get_attr(field, "fieldSmoothing")
             if (valid == True) and (field_smoothing != b"none") :
                 result_array += test_attr(field,v, "required",
-                                    "fieldSmoothingParameters", np.string_)
+                                    "fieldSmoothingParameters", np.bytes_)
 
     # Check the attributes in the SpeciesType extension
     if extensionStates['SpeciesType'] :
@@ -697,7 +697,7 @@ def check_meshes(f, iteration, v, extensionStates):
             field = f[full_meshes_path + field_name.encode('ascii')]
             # allowed are a-Z 0-9 - ; : (but no spaces!)
             result_array += test_attr(field, v, "optional",
-                                      "speciesType", np.string_,
+                                      "speciesType", np.bytes_,
                                       "^[a-zA-Z0-9\-;:]+$")
 
     return(result_array)
@@ -834,33 +834,33 @@ def check_particles(f, iteration, v, extensionStates) :
             result_array += test_attr(species, v, "required",
                                       "particleShape", [np.single, np.double, np.longdouble])
             result_array += test_attr(species, v, "required",
-                                      "currentDeposition", np.string_)
+                                      "currentDeposition", np.bytes_)
             result_array += test_attr(species, v, "required",
-                                      "particlePush", np.string_)
+                                      "particlePush", np.bytes_)
             result_array += test_attr(species, v, "required",
-                                      "particleInterpolation", np.string_)
+                                      "particleInterpolation", np.bytes_)
 
             # Check for the attributes associated with the particle boundaries
             result_array += test_attr(species, v, "required",
-                                    "particleBoundary", np.ndarray, np.string_)
+                                    "particleBoundary", np.ndarray, np.bytes_)
             valid, particle_boundary = get_attr(species, "particleBoundary")
             if (valid == True) and (np.any(particle_boundary == b"other")) :
                 result_array += test_attr(species, v, "required",
-                        "particleBoundaryParameters", np.ndarray, np.string_)
+                        "particleBoundaryParameters", np.ndarray, np.bytes_)
 
             # Check for the attributes associated with the particle smoothing
             result_array += test_attr(species, v, "required",
-                                      "particleSmoothing", np.string_)
+                                      "particleSmoothing", np.bytes_)
             valid, particle_smoothing = get_attr(species, "particleSmoothing")
             if valid == True and particle_smoothing != b"none":
                 result_array += test_attr(species, v, "required",
-                                "particleSmoothingParameters", np.string_)
+                                "particleSmoothingParameters", np.bytes_)
 
         # Check the attributes associated with the SpeciesType extension
         if extensionStates['SpeciesType'] :
             # allowed are a-Z 0-9 - ; : (but no spaces!)
             result_array += test_attr(species, v, "optional", "speciesType",
-                                      np.string_, "^[a-zA-Z0-9\-;:]+$")
+                                      np.bytes_, "^[a-zA-Z0-9\-;:]+$")
 
         # Check attributes of each record of the particle
         for record in list(species.keys()) :

--- a/openpmd_validator/createExamples_h5.py
+++ b/openpmd_validator/createExamples_h5.py
@@ -37,8 +37,8 @@ def get_basePath(f, iteration):
     -------
     A string with a in-file path.
     """
-    iteration_str = np.string_(str(iteration))
-    return np.string_(f.attrs["basePath"]).replace(b"%T", iteration_str)
+    iteration_str = np.bytes_(str(iteration))
+    return np.bytes_(f.attrs["basePath"]).replace(b"%T", iteration_str)
 
 def setup_base_path(f, iteration):
     """
@@ -67,7 +67,7 @@ def get_software_dependencies():
     Returns the software dependencies of this script as a semicolon
     separated string.
     """
-    return np.string_(
+    return np.bytes_(
         "python@{0}.{1}.{2};".format(
             sys.version_info.major,
             sys.version_info.minor,
@@ -92,25 +92,25 @@ def setup_root_attr(f):
     ext_list = ["ED-PIC", "SpeciesType"]
 
     # Required attributes
-    f.attrs["openPMD"] = np.string_("2.0.0")
-    f.attrs["openPMDextension"] = np.string_(";".join(ext_list))
-    f.attrs["basePath"] = np.string_("/data/%T/")
-    f.attrs["meshesPath"] = np.string_("meshes/")
-    f.attrs["particlesPath"] = np.string_("particles/")
-    f.attrs["iterationEncoding"] = np.string_("groupBased")
-    f.attrs["iterationFormat"] = np.string_("/data/%T/")
+    f.attrs["openPMD"] = np.bytes_("2.0.0")
+    f.attrs["openPMDextension"] = np.bytes_(";".join(ext_list))
+    f.attrs["basePath"] = np.bytes_("/data/%T/")
+    f.attrs["meshesPath"] = np.bytes_("meshes/")
+    f.attrs["particlesPath"] = np.bytes_("particles/")
+    f.attrs["iterationEncoding"] = np.bytes_("groupBased")
+    f.attrs["iterationFormat"] = np.bytes_("/data/%T/")
 
     # Recommended attributes
-    f.attrs["author"] = np.string_("Axel Huebl <a.huebl@hzdr.de>")
-    f.attrs["software"] = np.string_("openPMD Example Script")
-    f.attrs["softwareVersion"] = np.string_("2.0.0.0")
+    f.attrs["author"] = np.bytes_("Axel Huebl <a.huebl@hzdr.de>")
+    f.attrs["software"] = np.bytes_("openPMD Example Script")
+    f.attrs["softwareVersion"] = np.bytes_("2.0.0.0")
     f.attrs["softwareDependencies"] = get_software_dependencies()
-    f.attrs["machine"] = np.string_(socket.gethostname())
-    f.attrs["date"] = np.string_(
+    f.attrs["machine"] = np.bytes_(socket.gethostname())
+    f.attrs["date"] = np.bytes_(
         datetime.datetime.now(tzlocal()).strftime('%Y-%m-%d %H:%M:%S %z'))
 
     # Optional
-    f.attrs["comment"] = np.string_("This is a dummy file for test purposes.")
+    f.attrs["comment"] = np.bytes_("This is a dummy file for test purposes.")
 
 
 def write_rho_cylindrical(meshes, mode0, mode1):
@@ -133,18 +133,18 @@ def write_rho_cylindrical(meshes, mode0, mode1):
         (The first axis corresponds to r, and the second axis corresponds to z)
     """
     # Path to the rho meshes, within the h5py file
-    full_rho_path = np.string_("rho")
+    full_rho_path = np.bytes_("rho")
     meshes.create_dataset( full_rho_path, (3, mode0.shape[0], mode0.shape[1]), \
                            dtype=np.float32)
     rho = meshes[full_rho_path]
-    rho.attrs["comment"] = np.string_(
+    rho.attrs["comment"] = np.bytes_(
         "Density of electrons in azimuthal decomposition")
-    rho.attrs["speciesType"] = np.string_("electron")
+    rho.attrs["speciesType"] = np.bytes_("electron")
 
     # Create the dataset (cylindrical with azimuthal modes up to m=1)
     # The first axis has size 2m+1
-    rho.attrs["geometry"] = np.string_("thetaMode")
-    rho.attrs["geometryParameters"] = np.string_("m=1; imag=+")
+    rho.attrs["geometry"] = np.bytes_("thetaMode")
+    rho.attrs["geometryParameters"] = np.bytes_("m=1; imag=+")
 
     # Add information on the units of the data
     rho.attrs["unitSI"] = np.float64(1.0)
@@ -203,7 +203,7 @@ def write_b_2d_cartesian(meshes, data_ez):
     B.create_dataset(b"z", data_ez.shape, dtype=np.float32)
 
     # Write the common metadata for the group
-    B.attrs["geometry"] = np.string_("cartesian")
+    B.attrs["geometry"] = np.bytes_("cartesian")
     B.attrs["gridSpacing"] = np.array([1.0, 1.0], dtype=np.float32)   # dx, dy
     B.attrs["gridGlobalOffset"] = np.array([0.0, 0.0], dtype=np.float32)
     B.attrs["gridUnitSI"] = np.array([1.0, 1.0], dtype=np.float64)
@@ -268,7 +268,7 @@ def write_e_2d_cartesian(meshes, data_ex, data_ey, data_ez ):
     E.create_dataset(b"z", data_ez.shape, dtype=np.float32)
 
     # Write the common metadata for the group
-    E.attrs["geometry"] = np.string_("cartesian")
+    E.attrs["geometry"] = np.bytes_("cartesian")
     E.attrs["gridSpacing"] = np.array([1.0, 1.0], dtype=np.float32) # dx, dy
     E.attrs["gridGlobalOffset"] = np.array([0.0, 0.0], dtype=np.float32)
     E.attrs["gridUnitSI"] = np.array([1.0, 1.0], dtype=np.float64 )
@@ -317,9 +317,9 @@ def add_EDPIC_attr_meshes(field):
             and Dataset for scalar meshes)
 
     """
-    field.attrs["fieldSmoothing"] = np.string_("none")
+    field.attrs["fieldSmoothing"] = np.bytes_("none")
     # field.attrs["fieldSmoothingParameters"] = \
-    #     np.string_("period=10;numPasses=4;compensator=true")
+    #     np.bytes_("period=10;numPasses=4;compensator=true")
 
 
 def add_EDPIC_attr_particles(particle):
@@ -333,17 +333,17 @@ def add_EDPIC_attr_particles(particle):
                The group of the particle that gets additional attributes.
 
     """
-    particle.attrs["speciesType"] = np.string_("electron")
+    particle.attrs["speciesType"] = np.bytes_("electron")
     particle.attrs["particleShape"] = 3.0
-    particle.attrs["currentDeposition"] = np.string_("Esirkepov")
-    # particle.attrs["currentDepositionParameters"] = np.string_("")
-    particle.attrs["particlePush"] = np.string_("Boris")
-    particle.attrs["particleInterpolation"] = np.string_("uniform")
+    particle.attrs["currentDeposition"] = np.bytes_("Esirkepov")
+    # particle.attrs["currentDepositionParameters"] = np.bytes_("")
+    particle.attrs["particlePush"] = np.bytes_("Boris")
+    particle.attrs["particleInterpolation"] = np.bytes_("uniform")
     particle.attrs["particleBoundary"] = np.array(
             [b"periodic", b"periodic", b"absorbing", b"absorbing"])
-    particle.attrs["particleSmoothing"] = np.string_("none")
+    particle.attrs["particleSmoothing"] = np.bytes_("none")
     # particle.attrs["particleSmoothingParameters"] = \
-    #     np.string_("period=1;numPasses=2;compensator=false")
+    #     np.bytes_("period=1;numPasses=2;compensator=false")
 
 
 def write_meshes(f, iteration):
@@ -352,13 +352,13 @@ def write_meshes(f, iteration):
     meshes = f[full_meshes_path]
 
     # Extension: Additional attributes for ED-PIC
-    meshes.attrs["fieldSolver"] = np.string_("Yee")
+    meshes.attrs["fieldSolver"] = np.bytes_("Yee")
     meshes.attrs["fieldBoundary"] = np.array(
         [b"periodic", b"periodic", b"open", b"open"])
-    meshes.attrs["currentSmoothing"] = np.string_("Binomial")
+    meshes.attrs["currentSmoothing"] = np.bytes_("Binomial")
     meshes.attrs["currentSmoothingParameters"] = \
-         np.string_("period=1;numPasses=2;compensator=false")
-    meshes.attrs["chargeCorrection"] = np.string_("none")
+         np.bytes_("period=1;numPasses=2;compensator=false")
+    meshes.attrs["chargeCorrection"] = np.bytes_("none")
 
     # (Here the data is randomly generated, but in an actual simulation,
     # this would be replaced by the simulation data.)
@@ -386,7 +386,7 @@ def write_particles(f, iteration):
 
     globalNumParticles = 128 # example number of all particles
 
-    electrons.attrs["comment"] = np.string_("My first electron species")
+    electrons.attrs["comment"] = np.bytes_("My first electron species")
 
     # Extension: ED-PIC Attributes
     #   required


### PR DESCRIPTION
```
AttributeError: `np.string_` was removed in the NumPy 2.0 release.
Use `np.bytes_` instead.. Did you mean: 'strings'?
```
Same as #77